### PR TITLE
Crash fix in chat.cpp

### DIFF
--- a/src/GUI/Chat.cpp
+++ b/src/GUI/Chat.cpp
@@ -444,10 +444,13 @@ void Chat::gameStart()
 
 void Chat::navigateHistory(Sint32 direction)
 {
+	if (m_savedMessages.empty())
+		return;
+
 	Sint32 messagesSize = SDL_static_cast(Sint32, m_savedMessages.size()) - 1;
 	if(m_historyNavigator == SDL_MIN_SINT32)
 	{
-		if(m_savedMessages.empty() || direction > 0)
+		if(direction > 0)
 			return;
 
 		m_historyNavigator = messagesSize + 1;


### PR DESCRIPTION
How to reproduce a crash?
Just login, and send messages. Navigate into history (Shift + Up or Down) and this will work normally. But if you relog your character and try to navigate (Shift + Up) the client will crash.

We need to check if "m_savedMessages" is empty, because if this is empty we can't navigate in a empty history.